### PR TITLE
Updates to how we store user name data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.2.2
+* Updated the versions of various gem dependencies.
+* Updated the user sync to store the user name fields directly on the user. We'll remove them from the app_metadata in a future version.
+
+## 0.2.1
+* Replacing calls to UUIDTools::UUID.timestamp_create to be UUIDTools::UUID.random_create instead to resolve an error with GCloud hosting.
+
+## 0.2.0
+* No Changes (version bump).
+
+## 0.1.9
+* Updated the update_user call to not send the verification email if the email is already verified.
+
+## 0.1.8
+* Removed specific version requirement for json gem.
+* Loosened the jwt gem version dependency.
+
+## 0.1.7
+* Fixing issue with email uniqueness validation finding unrelated email addresses.
+
+## 0.1.6
+* Updating SyncAttrWithAuth0::Auth0#find_by_users back to using a lucene email search.
+
+## 0.1.5
+* Updating SyncAttrWithAuth0::Auth0#find_by_users to use new v2 users-by-email endpoint instead of a search.
+
+## 0.1.4
+* Upgrading the versions of gem dependencies, including jwt.
+
 ## 0.1.3
 * Renamed SyncAttrWithAuth0::Adapters::ActiveRecord::Sync to be Auth0Sync to prevent collisions.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Synchronize attributes on a local ActiveRecord user model with the user metadata
 
 This gem will validate the email is unique on auth0, create the user on auth0, as well as keep the information you select up-to-date with auth0.
 
+## Important info regarding v0.2.2
+We're migrating user name information off of the app_metadata hash, and instead setting them directly on the user (which is what it should have been doing). Make sure anything reading the user name, nickname, given_name, and family_name is no longer reading them from app_metadata.  For backwards compatibility, we're still syncing there with this version, but a future version will have it removed.
+
 ## Important info regarding v0.1
 There were significant changes to the configuration and usage of the gem as of v0.1.  The readme reflects the current version of that. Please see the changelog for more info about the changes.
 

--- a/lib/sync_attr_with_auth0/adapters/active_record.rb
+++ b/lib/sync_attr_with_auth0/adapters/active_record.rb
@@ -13,6 +13,7 @@ module SyncAttrWithAuth0
 
       module ClassMethods
 
+        # TODO: We should accept two arrays of fields: user_metadata (for user-managed settings) and app_metadata (for app-managed settings)
         def sync_attr_with_auth0(*fields)
           options = fields.extract_options!
 

--- a/lib/sync_attr_with_auth0/adapters/active_record/auth0_sync.rb
+++ b/lib/sync_attr_with_auth0/adapters/active_record/auth0_sync.rb
@@ -159,6 +159,10 @@ module SyncAttrWithAuth0
             'password' => password,
             'connection' => auth0_sync_configuration.connection_name,
             'email_verified' => email_verified,
+            'name' => auth0_user_name,
+            'nickname' => auth0_user_name,
+            'given_name' => auth0_user_given_name,
+            'family_name' => auth0_user_family_name,
             'user_metadata' => user_metadata,
             'app_metadata' => app_metadata
           }
@@ -172,6 +176,10 @@ module SyncAttrWithAuth0
           app_metadata = auth0_app_metadata
 
           params = {
+            'name' => auth0_user_name,
+            'nickname' => auth0_user_name,
+            'given_name' => auth0_user_given_name,
+            'family_name' => auth0_user_family_name,
             'app_metadata' => app_metadata,
             'user_metadata' => user_metadata
           }

--- a/spec/sync_attr_with_auth0/adapters/active_record/auth0_sync_spec.rb
+++ b/spec/sync_attr_with_auth0/adapters/active_record/auth0_sync_spec.rb
@@ -386,6 +386,9 @@ module SyncAttrWithAuth0
             allow(subject).to receive(:auth0_user_metadata).and_return(mock_user_metadata)
             allow(subject).to receive(:auth0_app_metadata).and_return(mock_app_metadata)
             allow(subject).to receive(:email).and_return('foo@email.com')
+            allow(subject).to receive(:given_name).and_return('John')
+            allow(subject).to receive(:family_name).and_return('Doe')
+            allow(subject).to receive(:name).and_return('John Doe')
             allow(subject).to receive(:auth0_default_password).and_return('default-password')
           end
 
@@ -396,6 +399,10 @@ module SyncAttrWithAuth0
                 'password' => 'some password',
                 'connection' => 'Username-Password-Authentication',
                 'email_verified' => false,
+                'family_name' => 'Doe',
+                'given_name' => 'John',
+                'name' => 'John Doe',
+                'nickname' => 'John Doe',
                 'app_metadata' => { 'bing' => 'jazz' },
                 'user_metadata' => { 'foo' => 'bar' }
               }
@@ -415,6 +422,10 @@ module SyncAttrWithAuth0
                 'password' => 'default-password',
                 'connection' => 'Username-Password-Authentication',
                 'email_verified' => false,
+                'family_name' => 'Doe',
+                'given_name' => 'John',
+                'name' => 'John Doe',
+                'nickname' => 'John Doe',
                 'app_metadata' => { 'bing' => 'jazz' },
                 'user_metadata' => { 'foo' => 'bar' }
               }
@@ -462,6 +473,10 @@ module SyncAttrWithAuth0
                 'password' => 'default-password',
                 'connection' => 'Username-Password-Authentication',
                 'email_verified' => false,
+                'family_name' => 'Doe',
+                'given_name' => 'John',
+                'name' => 'John Doe',
+                'nickname' => 'John Doe',
                 'app_metadata' => { 'bing' => 'jazz' },
                 'user_metadata' => { 'foo' => 'bar' }
               }
@@ -509,6 +524,10 @@ module SyncAttrWithAuth0
                 'password' => 'default-password',
                 'connection' => 'Username-Password-Authentication',
                 'email_verified' => true,
+                'family_name' => 'Doe',
+                'given_name' => 'John',
+                'name' => 'John Doe',
+                'nickname' => 'John Doe',
                 'app_metadata' => { 'bing' => 'jazz' },
                 'user_metadata' => { 'foo' => 'bar' }
               }
@@ -542,11 +561,18 @@ module SyncAttrWithAuth0
             allow(subject).to receive(:auth0_app_metadata).and_return(mock_app_metadata)
             allow(subject).to receive(:email).and_return('foo@email.com')
             allow(subject).to receive(:password).and_return('some password')
+            allow(subject).to receive(:given_name).and_return('John')
+            allow(subject).to receive(:family_name).and_return('Doe')
+            allow(subject).to receive(:name).and_return('John Doe')
           end
 
           context "when the password and email are not changed" do
             let(:expected_response) do
               {
+                'family_name' => 'Doe',
+                'given_name' => 'John',
+                'name' => 'John Doe',
+                'nickname' => 'John Doe',
                 'app_metadata' => { 'bing' => 'jazz' },
                 'user_metadata' => { 'foo' => 'bar' }
               }
@@ -560,6 +586,10 @@ module SyncAttrWithAuth0
           context "when the password is changed" do
             let(:expected_response) do
               {
+                'family_name' => 'Doe',
+                'given_name' => 'John',
+                'name' => 'John Doe',
+                'nickname' => 'John Doe',
                 'app_metadata' => { 'bing' => 'jazz' },
                 'user_metadata' => { 'foo' => 'bar' },
                 'password' => 'some password',
@@ -582,6 +612,10 @@ module SyncAttrWithAuth0
 
               let(:expected_response) do
                 {
+                  'family_name' => 'Doe',
+                  'given_name' => 'John',
+                  'name' => 'John Doe',
+                  'nickname' => 'John Doe',
                   'app_metadata' => { 'bing' => 'jazz' },
                   'user_metadata' => { 'foo' => 'bar' },
                   'email' => 'foo@email.com',
@@ -599,6 +633,10 @@ module SyncAttrWithAuth0
 
               let(:expected_response) do
                 {
+                  'family_name' => 'Doe',
+                  'given_name' => 'John',
+                  'name' => 'John Doe',
+                  'nickname' => 'John Doe',
                   'app_metadata' => { 'bing' => 'jazz' },
                   'user_metadata' => { 'foo' => 'bar' },
                   'email' => 'foo@email.com',

--- a/sync_attr_with_auth0.gemspec
+++ b/sync_attr_with_auth0.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'sync_attr_with_auth0'
-  gem.version       = '0.2.1'
+  gem.version       = '0.2.2'
   gem.date          = '2016-07-26'
   gem.summary       = "Synchronize attributes on a local ActiveRecord user model with the user metadata store on Auth0"
   gem.description   = gem.summary


### PR DESCRIPTION
Updated the create and update params to include the user name fields.  Added info about removing them from app_metadata.

Bumped the version.